### PR TITLE
fix: avoid mobile wallet connect dialog cut off

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js"></script>
   </head>
-  <body class="min-h-screen flex items-center justify-center py-8">
-    <div>
+  <body class="min-h-screen flex flex-col items-center justify-center py-8">
+    <div class="w-full">
       <div id="urlSection" class="mb-8 max-w-xl">
         <div class="mb-3 text-sm">
           Comment IDs are 32-byte hex strings (66 characters including 0x


### PR DESCRIPTION
1. if the message is short, md will not use full width available, so added `w-full` to fix. see pic for the issue

## Issues
<img width="312" alt="image" src="https://github.com/user-attachments/assets/aa38e5ad-e948-4e7e-ae22-5f9be6c116c3" />

<img width="312" alt="image" src="https://github.com/user-attachments/assets/8af43d8c-ffc7-480a-ba2c-754cecb09330" />
